### PR TITLE
Remove dependency on bacio

### DIFF
--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -12,7 +12,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 include(CMakeFindDependencyMacro)
 
 find_dependency(PNG)
-find_dependency(bacio)
 
 get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)
 


### PR DESCRIPTION
We removed find_package(bacio) from the main CMakeLists.txt, but not from here. 