### PR TITLE
Remove 'save' attribute on idxlist and deallocate entry if it already exists

### DIFF
--- a/src/getidx.f
+++ b/src/getidx.f
@@ -72,7 +72,7 @@ C$$$
          character(len=1),pointer,dimension(:) :: cbuf
       END TYPE GINDEX
      
-      TYPE(GINDEX),SAVE :: IDXLIST(10000)
+      TYPE(GINDEX) :: IDXLIST(10000)
 
       DATA LUX/0/
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -111,6 +111,11 @@ C  DETERMINE WHETHER INDEX BUFFER NEEDS TO BE INITIALIZED
          IDXLIST(LUGB)%NNUM=0
          LUX=0
       ENDIF
+
+      IF (ASSOCIATED(IDXLIST(LUGB)%CBUF)) then
+         DEALLOCATE(IDXLIST(LUGB)%CBUF)
+      end if
+
       IF (LUGI.LT.0) THEN      ! Force re-read of index from indexfile
                                ! associated with unit abs(lugi)
          IF ( ASSOCIATED( IDXLIST(LUGB)%CBUF ) ) 


### PR DESCRIPTION
This fixes a bug reported by Biju where passing the same file unit (LUGB) results in an error.

I ran a diff between what was in `getidxes.f` and what is currently in `getidx.f` and changed `getidx.f` to match.

Looks like it checks if an entry with the file unit (`LUGB`) already exists and deallocates it before proceeding, but in `getidx.f` this check wasn't there.

I also removed the `save` attribute from `idxlist`.

@BoiVuong-NOAA what do you think of these changes? I'm not really sure why the one version had this check, or why `idxlist` was marked as `save`.