### PR TITLE
Remove ORG and add full author name, Part of issue #55

### DIFF
--- a/src/addfield.f
+++ b/src/addfield.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief Contains subroutine which packs up Sections 4 through 7 for
 !>    a given field and adds them to a GRIB2 message.
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-02
+!>    @author Stephen Gilbert @date 2000-05-02
 !>     
 !>    This subroutine packs up Sections 4 through 7 for a given field
 !>    and adds them to a GRIB2 message. They are Product Definition
@@ -18,10 +18,10 @@
 !>    added.
 !>
 !>    PROGRAM HISTORY LOG:
-!>    - 2000-05-02 Gilbert
-!>    - 2002-12-17 Gilbert - Added support for new templates using
+!>    - 2000-05-02 Stephen Gilbert
+!>    - 2002-12-17 Stephen Gilbert - Added support for new templates using
 !>    PNG and JPEG2000 algorithms/templates.
-!>    - 2004-06-22 Gilbert - Added check to determine if packing algorithm failed.
+!>    - 2004-06-22 Stephen Gilbert - Added check to determine if packing algorithm failed.
 !>
 !>    @param[inout] cgrib Character array to contain the GRIB2 message.
 !>    @param[in] lcgrib Maximum length (bytes) of array cgrib.
@@ -77,7 +77,7 @@
 !>    @note Note that the Local Use Section (Section 2) can only follow
 !>    Section 1 or Section 7 in a GRIB2 message.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-02
+!>    @author Stephen Gilbert @date 2000-05-02
 !>
       subroutine addfield(cgrib,lcgrib,ipdsnum,ipdstmpl,ipdstmplen,
      & coordlist,numcoord,idrsnum,idrstmpl,

--- a/src/addgrid.f
+++ b/src/addgrid.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This subroutine packs up a Grid Definition Section
 !>    (Section 3) and adds it to a GRIB2 message.
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-01
+!>    @author Stephen Gilbert @date 2000-05-01
 !>     
 !>    This routine is used with routines gribcreate(), addlocal(), addfield(),
 !>    and gribend() to create a complete GRIB2 message. Subroutine
@@ -39,7 +39,7 @@
 !>    @note: Note that the Local Use Section ( Section 2 ) can only follow
 !>          Section 1 or Section 7 in a GRIB2 message.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-01
+!>    @author Stephen Gilbert @date 2000-05-01
 !>
 
       subroutine addgrid(cgrib,lcgrib,igds,igdstmpl,igdstmplen,

--- a/src/addlocal.f
+++ b/src/addlocal.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This subroutine adds a Local Use Section (Section 2) to
 !>    a GRIB2 message.
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-01
+!>    @author Stephen Gilbert @date 2000-05-01
 !>    
 
 !>    This subroutine adds a Local Use Section (Section 2) to a GRIB2 message.
@@ -25,7 +25,7 @@
 !>    @note Note that the Local Use Section ( Section 2 ) can only follow
 !>    Section 1 or Section 7 in a GRIB2 message.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2000-05-01
+!>    @author Stephen Gilbert @date 2000-05-01
 !>
 
       subroutine addlocal(cgrib,lcgrib,csec2,lcsec2,ierr)

--- a/src/cmplxpack.f
+++ b/src/cmplxpack.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This subroutine packs up a data field using a complex
 !>    packing algorithm as defined in the GRIB2 documention.
-!>    @author Gilbert ORG: W/NP11 @date 2004-08-27
+!>    @author Stephen Gilbert @date 2004-08-27
 !>     
 
 !>    This subroutine packs up a data field using a complex
@@ -25,7 +25,7 @@
 !>    @param[out] cpack The packed data field (character*1 array)
 !>    @param[out] lcpack length of packed field cpack.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2004-08-27
+!>    @author Stephen Gilbert @date 2004-08-27
 !>
 
       subroutine cmplxpack(fld,ndpts,idrsnum,idrstmpl,cpack,lcpack)

--- a/src/compack.f
+++ b/src/compack.f
@@ -1,6 +1,6 @@
 !>    @file
 !>    @brief This subroutine packs up a data field.
-!>    @author Gilbert ORG: W/NP11 @date 2000-06-21
+!>    @author Stephen Gilbert @date 2000-06-21
 !>     
 
 !>    This subroutine packs up a data field.
@@ -25,7 +25,7 @@
 !>    @param[out] cpack The packed data field (character*1 array)
 !>    @param[out] lcpack length of packed field cpack.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2000-06-21
+!>    @author Stephen Gilbert @date 2000-06-21
 !>
 
       subroutine compack(fld,ndpts,idrsnum,idrstmpl,cpack,lcpack)

--- a/src/comunpack.f
+++ b/src/comunpack.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This subroutine unpacks a data field that was packed using a
 !>    complex packing algorithm as defined in the GRIB2 documention.
-!>    @author Gilbert ORG: W/NP11 @date 2000-06-21
+!>    @author Stephen Gilbert @date 2000-06-21
 !>     
 
 !>    This subroutine unpacks a data field that was packed using a
@@ -11,8 +11,8 @@
 !>    spatial differences (i.e. DRTs 5.2 and 5.3).
 !>    
 !>    PROGRAM HISTORY LOG:
-!>    - 2000-06-21  Gilbert
-!>    - 2004-12-29  Gilbert  -  Added test ( provided by Arthur Taylor/MDL )
+!>    - 2000-06-21  Stephen Gilbert
+!>    - 2004-12-29  Stephen Gilbert  -  Added test ( provided by Arthur Taylor/MDL )
 !>    to verify that group widths and lengths are consistent with section length.
 !>    - 2016-02-26              update unpacking for template 5.3
 !>
@@ -29,7 +29,7 @@
 !>    - 0 = OK
 !>    - 1 = Problem - inconsistent group lengths of widths.
 !>
-!>    @author Gilbert ORG: W/NP11 @date 2000-06-21
+!>    @author Stephen Gilbert @date 2000-06-21
 !>
 
       subroutine comunpack(cpack,len,lensec,idrsnum,idrstmpl,ndpts,

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -41,9 +41,9 @@
  * @param[in] injpc Input JPEG2000 code stream.
  * @param[in] bufsize Length (in bytes) of the input JPEG2000 code stream.
  * @param[in] outfld Output matrix of grayscale image values. Only grayscale is expected.
- * @return 0 = Successful decode
- *         - -3 = Error decode jpeg2000 code stream.
- *         - -5 = decoded image had multiple color components.
+ * @return 0 Successful decode
+ *         - -3 Error decode jpeg2000 code stream.
+ *         - -5 decoded image had multiple color components.
  *
  * @note Requires JasPer Software version 1.500.4 or 1.700.2
  *

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -2,7 +2,7 @@
  * @file
  * @brief This Function decodes a JPEG2000 code stream specified in the
  * JPEG2000 Part-1 standard.
- * @author Gilbert ORG: W/NP11 @date 2002-12-02
+ * @author Stephen Gilbert @date 2002-12-02
  */
 
 #include <stdio.h>
@@ -41,13 +41,13 @@
  * @param[in] injpc Input JPEG2000 code stream.
  * @param[in] bufsize Length (in bytes) of the input JPEG2000 code stream.
  * @param[in] outfld Output matrix of grayscale image values. Only grayscale is expected.
- * @return - > 0 = Successful decode
+ * @return 0 = Successful decode
  *         - -3 = Error decode jpeg2000 code stream.
  *         - -5 = decoded image had multiple color components.
  *
  * @note Requires JasPer Software version 1.500.4 or 1.700.2
  *
- * @author Gilbert ORG: W/NP11 @date 2002-12-02
+ * @author Stephen Gilbert @date 2002-12-02
  */
    int SUB_NAME(char *injpc,g2int *bufsize,g2int *outfld)
 {

--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This program reads PNG stream data from memory.
- * @author Gilbert
+ * @author Stephen Gilbert
  */
 
 #include <stdio.h>

--- a/src/drstemplates.f
+++ b/src/drstemplates.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This Fortran Module contains info on all the available
 !>    GRIB2 Data Representation Templates used in Section 5 (DRS).
-!>    @author Gilbert ORG: W/NP11 @date 2001-04-03
+!>    @author Stephen Gilbert @date 2001-04-03
 !>     
 
 !>    This Fortran Module contains info on all the available
@@ -32,7 +32,7 @@
 !>    in this case would be the absolute value of the negative value in 
 !>    mapgrid.
 !>     
-!>    @author Gilbert ORG: W/NP11 @date 2001-04-03
+!>    @author Stephen Gilbert @date 2001-04-03
 !>
       module drstemplates
 
@@ -112,16 +112,16 @@
 
 !>    @brief  This function returns the index of specified Data
 !>    Representation Template 5.NN (NN=number) in array templates.                                    .
-!>    @author Gilbert         ORG: W/NP11    @date 2001-06-28
+!>    @author Stephen Gilbert            @date 2001-06-28
 !>     
 
 !>    @param[in] number NN, indicating the number of the Data Representation 
 !>    Template 5.NN that is being requested.
 !>
-!>    @return - > Index of DRT 5.NN in array templates, if template exists.
+!>    @return Index of DRT 5.NN in array templates, if template exists.
 !>    = -1, otherwise.
 !>
-!>    @author Gilbert         ORG: W/NP11    @date 2001-06-28
+!>    @author Stephen Gilbert            @date 2001-06-28
 !>
          integer function getdrsindex(number)
            integer,intent(in) :: number
@@ -139,7 +139,7 @@
 
 !>    @brief This subroutine returns DRS template information for a                                   .
 !>    specified Data Representation Template 5.NN.
-!>    @author Gilbert         ORG: W/NP11    @date 2000-05-11
+!>    @author Stephen Gilbert            @date 2000-05-11
 !>     
 
 !>    The number of entries in the template is returned along with a map
@@ -157,7 +157,7 @@
 !>    - 0 = no error
 !>    - 1 = Undefined Data Representation Template number.
 !>
-!>    @author Gilbert         ORG: W/NP11    @date 2000-05-11
+!>    @author Stephen Gilbert            @date 2000-05-11
 !>
          subroutine getdrstemplate(number,nummap,map,needext,iret)
            integer,intent(in) :: number
@@ -184,7 +184,7 @@
 
 !>    @brief This subroutine generates the remaining octet map for a
 !>    given Data Representation Template, if required.
-!>    @author  Gilbert         ORG: W/NP11    @date 2000-05-11
+!>    @author  Stephen Gilbert            @date 2000-05-11
 !>     
 
 !>    Some Templates can vary depending on data values given in an earlier part 
@@ -199,7 +199,7 @@
 !>    @param[out] map An array containing the number of octets that each 
 !>    template entry occupies when packed up into the GDS.
 !>
-!>    @author  Gilbert         ORG: W/NP11    @date 2000-05-11
+!>    @author  Stephen Gilbert            @date 2000-05-11
 !>
          subroutine extdrstemplate(number,list,nummap,map)
            integer,intent(in) :: number,list(*)

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -56,9 +56,9 @@
  * 1 = try increasing number of guard bits otherwise, no additional options
  * @param[in] jpclen  - Number of bytes allocated for new JPEG2000 code stream in outjpc.
  * @param[in] outjpc - Output encoded JPEG2000 code stream
- * @return 0 = Length in bytes of encoded JPEG2000 code stream
- *         -  -3 = Error decode jpeg2000 code stream.
- *         -  -5 = decoded image had multiple color components.
+ * @return 0 successfully decode JPEG2000 code stream
+ *         -  -3 Error decode jpeg2000 code stream.
+ *         -  -5 decoded image had multiple color components.
  * Only grayscale is expected.
  *
  * @note Requires JasPer Software version 1.500.4 or 1.700.2

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -39,7 +39,7 @@
  *  
  * PROGRAM HISTORY LOG:
  * - 2002-12-02  Stephen Gilbert
- * - 2004-07-20  GIlbert - Added retry argument/option to allow option of
+ * - 2004-07-20  Stephen Gilbert - Added retry argument/option to allow option of
  * increasing the maximum number of guard bits to the JPEG2000 algorithm.
  *
  * @param[in] cin Packed matrix of Grayscale image values to encode.

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -2,7 +2,7 @@
  * @file
  * @brief This Function encodes a grayscale image into a JPEG2000 code stream
  * specified in the JPEG2000 Part-1 standard.
- * @author Gilbert ORG: W/NP11 @date 2002-12-02
+ * @author Stephen Gilbert @date 2002-12-02
  */
 
 #include <stdio.h>
@@ -38,7 +38,7 @@
  * JasPer is available at http: *   www.ece.uvic.ca/~mdadams/jasper/.
  *  
  * PROGRAM HISTORY LOG:
- * - 2002-12-02  Gilbert
+ * - 2002-12-02  Stephen Gilbert
  * - 2004-07-20  GIlbert - Added retry argument/option to allow option of
  * increasing the maximum number of guard bits to the JPEG2000 algorithm.
  *
@@ -56,14 +56,14 @@
  * 1 = try increasing number of guard bits otherwise, no additional options
  * @param[in] jpclen  - Number of bytes allocated for new JPEG2000 code stream in outjpc.
  * @param[in] outjpc - Output encoded JPEG2000 code stream
- * @return - > 0 = Length in bytes of encoded JPEG2000 code stream
+ * @return 0 = Length in bytes of encoded JPEG2000 code stream
  *         -  -3 = Error decode jpeg2000 code stream.
  *         -  -5 = decoded image had multiple color components.
  * Only grayscale is expected.
  *
  * @note Requires JasPer Software version 1.500.4 or 1.700.2
  *
- * @author Gilbert ORG: W/NP11 @date 2002-12-02
+ * @author Stephen Gilbert @date 2002-12-02
  */
 int SUB_NAME(unsigned char *cin,g2int *pwidth,g2int *pheight,g2int *pnbits,
                  g2int *ltype, g2int *ratio, g2int *retry, char *outjpc,

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This program writes PNG stream to memory.
- * @author Gilbert
+ * @author Stephen Gilbert
  */
 
 #include <stdio.h>

--- a/src/g2grids.f
+++ b/src/g2grids.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This Fortran Module allows access to predefined GRIB2 Grid
 !>    Definition Templates stored in a file.
-!>    @author Gilbert ORG: W/NP11 @date 2004-04-27
+!>    @author Gilbert @date 2004-04-27
 !>
 
 !>    This Fortran Module allows access to predefined GRIB2 Grid
@@ -24,7 +24,7 @@
 !>    As an example, this is the entry for the 1x1 GFS global grid
 !>    3:gbl_1deg: 0:19: 0 0 0 0 0 0 0 360 181 0 0 90000000 0 48 -90000000 359000000 1000000 1000000 0
 !>
-!>    @author Stephen Gilbert ORG: W/NP11 @date 2004-04-27
+!>    @author Stephen Gilbert @date 2004-04-27
 !>
 
       module g2grids
@@ -51,7 +51,7 @@
 !>
 !>    @param[in] lunit Fortran unit number associated the the GDT file.
 !>    @return The number of Grid Definition Templates read in.
-!>    @author Gilbert         ORG: W/NP11    @date 2001-06-28
+!>    @author Stephen Gilbert  @date 2001-06-28
 !>
 
          integer function readgrids(lunit)
@@ -143,7 +143,7 @@
 !>    - -1 Undefined Grid number.
 !>    - 3 Could not read any grids from file.
 !>
-!>    @author Stephen Gilbert ORG: W/NP11 @date 2004-04-26
+!>    @author Stephen Gilbert @date 2004-04-26
 !>
 
          subroutine getgridbynum(lunit,number,igdtn,igdtmpl,iret)
@@ -205,7 +205,7 @@
 !>    - -1 Undefined Grid name.
 !>    - 3 Could not read any grids from file.
 !>
-!>    @author Stephen Gilbert ORG: W/NP11 @date 2004-04-26
+!>    @author Stephen Gilbert @date 2004-04-26
 !>
 
          subroutine getgridbyname(lunit,name,igdtn,igdtmpl,iret)

--- a/src/g2grids.f
+++ b/src/g2grids.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This Fortran Module allows access to predefined GRIB2 Grid
 !>    Definition Templates stored in a file.
-!>    @author Gilbert @date 2004-04-27
+!>    @author Stephen Gilbert @date 2004-04-27
 !>
 
 !>    This Fortran Module allows access to predefined GRIB2 Grid

--- a/src/gb_info.f
+++ b/src/gb_info.f
@@ -1,7 +1,7 @@
 !>    @file
 !>    @brief This subroutine searches the number of gridded fields and
 !>    the number of Local Use Sections through a GRIB2 message.
-!>    @author Stephen Gilbert ORG: W/NP11 @date 2000-05-25
+!>    @author Stephen Gilbert @date 2000-05-25
 !>
 
 !>    This subroutine searches through a GRIB2 message and
@@ -47,7 +47,7 @@
 !>    - 5 End string "7777" not found at end of message.
 !>    - 6 Invalid section number found.
 !>
-!>    @author Stephen Gilbert ORG: W/NP11 @date 2000-05-25
+!>    @author Stephen Gilbert @date 2000-05-25
 !>
 
       subroutine gb_info(cgrib,lcgrib,listsec0,listsec1,


### PR DESCRIPTION
This is part of issue #55 
According to Edward's decision, the ORG info is removed.
The Full name of author is added for all doxygen added code files.