### PR TITLE
solve the final warnings for g2 doxygen, close of issue #55

### DIFF
--- a/src/drstemplates.f
+++ b/src/drstemplates.f
@@ -36,7 +36,9 @@
 !>
       module drstemplates
 
-      integer,parameter :: MAXLEN=200,MAXTEMP=9
+      integer,parameter :: MAXLEN=200 !< maximum number of octets in mapgrid
+      integer,parameter :: MAXTEMP=9 !< maximum number of entries in the template
+
 
       type drstemplate
           integer :: template_num
@@ -45,7 +47,7 @@
           logical :: needext
       end type drstemplate
 
-      type(drstemplate),dimension(MAXTEMP) :: templates
+      type(drstemplate),dimension(MAXTEMP) :: templates !< template in type of drstemplate
 
       data templates(1)%template_num /0/     !<     Simple Packing
       data templates(1)%mapdrslen /5/ 

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -61,7 +61,8 @@
  * - -3 Error decode jpeg2000 code stream.
  * - -5 decoded image had multiple color components.
  * Only grayscale is expected.
- *
+ * @var int MAXOPTSSIZE
+ * 
  * @note Requires JasPer Software version 1.500.4 or 1.700.2
  *
  * @author Stephen Gilbert @date 2002-12-02
@@ -74,7 +75,11 @@ int SUB_NAME(unsigned char *cin,g2int *pwidth,g2int *pheight,g2int *pnbits,
     jas_image_t image;
     jas_stream_t *jpcstream,*istream;
     jas_image_cmpt_t cmpt,*pcmpt;
-#define MAXOPTSSIZE 1024 /**< Maximum size of the options. */
+/**
+ * \def MAXOPTSSIZE
+ * Maximum size of the options.
+*/
+#define MAXOPTSSIZE 1024 
     char opts[MAXOPTSSIZE];
 
     g2int width,height,nbits;


### PR DESCRIPTION
Final of issue #55
The warning in enc_jpeg2000.c was finally solved. 
And others have been fixed too.
https://hang-lei-noaa.github.io/NCEPLIBS/NCEPLIBS-g2/html/files.html