### PR TITLE
Add `save`to idxlist to improve performance

### DIFF
--- a/src/getidx.f
+++ b/src/getidx.f
@@ -58,7 +58,7 @@ C-----------------------------------------------------------------------
          character(len=1),pointer,dimension(:) :: cbuf
       END TYPE GINDEX
      
-      TYPE(GINDEX) :: IDXLIST(10000)
+      TYPE(GINDEX), save :: IDXLIST(10000)
 
       DATA LUX/0/
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Fix #104 

Tested on WCOSS2 and the runtime was brought down from 25s with v3.4.1 to 2s.

@BoiVuong-NOAA will this break #52 where duplicate I/O units caused an error?

I'm pretty sure that was fixed by this line:

https://github.com/NOAA-EMC/NCEPLIBS-g2/blob/7e78071c76e23132acf1d5dd75d0250953bd6a25/src/getidx.f#L101

And the `save` had nothing to do with it.

I wonder if I could ask @BijuThomas-NOAA whether this build works for you? I can't find the original reproducer you sent me.