### PR TITLE
Don't regenerate grib index every time

### DIFF
--- a/src/getidx.f
+++ b/src/getidx.f
@@ -98,10 +98,6 @@ C  DETERMINE WHETHER INDEX BUFFER NEEDS TO BE INITIALIZED
          LUX=0
       ENDIF
 
-      IF (ASSOCIATED(IDXLIST(LUGB)%CBUF)) then
-         DEALLOCATE(IDXLIST(LUGB)%CBUF)
-      end if
-
       IF (LUGI.LT.0) THEN      ! Force re-read of index from indexfile
                                ! associated with unit abs(lugi)
          IF ( ASSOCIATED( IDXLIST(LUGB)%CBUF ) ) 


### PR DESCRIPTION
Fix #104 (for real this time). 

There was a mixup in the libraries used in testing and it was (incorrectly) believed that #105 fixed the performance hit noticed when transitioning to WCOSS.

There is a large performance penalty in re-generating the index every time. The index can be force regenerated if necessary with: 

If LUGI equals LUGB, the index will be regenerated from  the data in file LUGB. If LUGI is less than zero, then the index is re read from index file abs(lugi).