### PR TITLE
doxygen fixes and turn on WARN_AS_ERROR

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -791,7 +791,7 @@ WARN_NO_PARAMDOC       = YES
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -1005,13 +1005,13 @@ STRIP_CODE_COMMENTS    = YES
 # entity all documented functions referencing it will be listed.
 # The default value is: NO.
 
-REFERENCED_BY_RELATION = NO
+REFERENCED_BY_RELATION = YES
 
 # If the REFERENCES_RELATION tag is set to YES then for each documented function
 # all documented entities called/used by that function will be listed.
 # The default value is: NO.
 
-REFERENCES_RELATION    = NO
+REFERENCES_RELATION    = YES
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
 # to YES then the hyperlinks from functions in REFERENCES_RELATION and

--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -40,13 +40,15 @@ typedef struct png_stream png_stream; /**< location to write PNG stream */
 
 void user_read_data(png_structp , png_bytep , png_uint_32 );
 
-void user_read_data(png_structp png_ptr,png_bytep data, png_uint_32 length)
-
 /**
  * Custom read function used so that libpng will read a PNG stream
  * from memory instead of a file on disk.
+ *
+ * @param png_ptr pointer to png.
+ * @param data the data.
+ * @param length length of data.
 */
-
+void user_read_data(png_structp png_ptr,png_bytep data, png_uint_32 length)
 {
      char *ptr;
      g2int offset;

--- a/src/drstemplates.f
+++ b/src/drstemplates.f
@@ -112,11 +112,9 @@
 
       contains
 
-!>    @brief  This function returns the index of specified Data
+!>    This function returns the index of specified Data
 !>    Representation Template 5.NN (NN=number) in array templates.                                    .
-!>    @author Stephen Gilbert            @date 2001-06-28
 !>     
-
 !>    @param[in] number NN, indicating the number of the Data Representation 
 !>    Template 5.NN that is being requested.
 !>
@@ -139,11 +137,9 @@
 
          end function
 
-!>    @brief This subroutine returns DRS template information for a                                   .
+!>    This subroutine returns DRS template information for a                                   .
 !>    specified Data Representation Template 5.NN.
-!>    @author Stephen Gilbert            @date 2000-05-11
-!>     
-
+!>
 !>    The number of entries in the template is returned along with a map
 !>    of the number of octets occupied by each entry. Also, a flag is
 !>    returned to indicate whether the template would need to be extended.
@@ -184,11 +180,9 @@
 
          end subroutine
 
-!>    @brief This subroutine generates the remaining octet map for a
+!>    This subroutine generates the remaining octet map for a
 !>    given Data Representation Template, if required.
-!>    @author  Stephen Gilbert            @date 2000-05-11
 !>     
-
 !>    Some Templates can vary depending on data values given in an earlier part 
 !>    of the Template, and it is necessary to know some of the earlier entry
 !>    values to generate the full octet map of the Template.

--- a/src/drstemplates.f
+++ b/src/drstemplates.f
@@ -113,7 +113,7 @@
       contains
 
 !>    This function returns the index of specified Data
-!>    Representation Template 5.NN (NN=number) in array templates.                                    .
+!>    Representation Template 5.NN (NN=number) in array templates.
 !>     
 !>    @param[in] number NN, indicating the number of the Data Representation 
 !>    Template 5.NN that is being requested.
@@ -137,7 +137,7 @@
 
          end function
 
-!>    This subroutine returns DRS template information for a                                   .
+!>    This subroutine returns DRS template information for a
 !>    specified Data Representation Template 5.NN.
 !>
 !>    The number of entries in the template is returned along with a map

--- a/src/gf_free.f
+++ b/src/gf_free.f
@@ -10,8 +10,7 @@
 !>    - 2000-05-26 Stephen Gilbert Modified from getg1s to work with grib2
 !>    - 2012-12-11 Boi Vuong initialize an undefine pointers
 !>    - 2015-10-29 Boi Vuong Deallocate pointers in derived type gribfield
-!>    @param[in] gfld derived type gribfield (defined in module grib_mod)
-!>    @param[out] gfld derived type gribfield (defined in module grib_mod)
+!>    @param gfld derived type gribfield (defined in module grib_mod)
 !>    (NOTE: See Remarks Section)
 !>    - gfld\%version GRIB edition number (currently 2)
 !>    - gfld\%discipline Message Discipline (see Code Table 0.0)

--- a/src/gf_unpack7.f
+++ b/src/gf_unpack7.f
@@ -20,7 +20,6 @@
 !>    for the specified Grid Definition. Template (N=igdsnum). Each element of this
 !>    integer array contains an entry (in the order specified) of Grid Definition
 !>    Template 3.N (Only required to unpack DRT 5.51).
-!>    @param[in] ndpts Number of data points unpacked and returned.
 !>    @param[in] idrsnum Data Representation Template Number (Code Table 5.0).
 !>    @param[in] idrstmpl Pointer to an integer array containing the data values for
 !>    the specified Data Representation Template (N=idrsnum). Each element of this 

--- a/src/gribmod.f
+++ b/src/gribmod.f
@@ -150,7 +150,7 @@
 
       module grib_mod
 
-      character(len=12) :: G2_VERSION="g2lib-3.1.0"
+      character(len=12) :: G2_VERSION="g2lib-3.5.0" !< Library version.
 
       type gribfield
           integer :: version,discipline


### PR DESCRIPTION
Fixes #124 
Fixes #118 
Part of #123 
Fixes #126 

Fixing doxygen problems.

Also turned on doxygen WARN_AS_ERROR flag. Now doxygen warnings in the code will cause CI to fail. ;-)