### PR TITLE
fixing CMake hack in use of PNG in MacOS CI build

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: install-dependencies
       run: |
+        find /Library/Frameworks/ -name "png*"
+        sudo rm -rf /Library/Frameworks/Mono.framework
         brew update
         brew install libpng
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,7 @@ endif()
 # There was a bug in jasper for the intel compiler that was fixed in
 # 2.0.25.
 find_package(Jasper 2.0.25 REQUIRED)
-
-# Need to find PNG this way or it doesn't work on MacOS.
-include(FindPkgConfig)
-pkg_check_modules(PNG libpng16 REQUIRED)
-#find_package(PNG REQUIRED)
+find_package(PNG REQUIRED)
 find_package(bacio REQUIRED)
 
 add_subdirectory(src)


### PR DESCRIPTION
Fixes #205 

The MacOS needs a little help finding the right PNG library. I had hacked the CMake to do this, but since then have learned of a much better way, which is to hack the CI for macOS to make it work.

I already did this in the g2c, this PR does it for g2.
