### PR TITLE
allow FTP test file download for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,16 @@ if(bacio_VERSION LESS 2.5.0)
 endif()
 find_package(w3emc 2.9.0 REQUIRED)
 
+# Handle user build options.
+option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
+option(FTP_TEST_FILES "Fetch and test with files on FTP site." OFF)
 option(BUILD_4 "Build libg2_4.a" ON)
 option(BUILD_D "Build libg2_d.a" ON)
 
+# Build the code in the source directory.
 add_subdirectory(src)
 
+# Unit testing.
 include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(tests)
@@ -45,7 +50,6 @@ if(BUILD_TESTING)
 endif()
 
 # Determine whether or not to generate documentation.
-option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 if(ENABLE_DOCS)
   find_package(Doxygen REQUIRED)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,24 +11,54 @@ set(lib_src creategrib.f90)
 add_library(g2_test_lib STATIC ${lib_src})
 target_link_libraries(g2_test_lib PRIVATE bacio::bacio)
 
-# Copy test data file to the build directory.
+# Some test files are large and are kept on the NOAA EMC FTP
+# site. This function is used to download such test data. It takes two
+# arguments, the URL and the file to be downloaded.
+function(PULL_DATA THE_URL THE_FILE)
+  if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}")
+    file(DOWNLOAD
+      ${THE_URL}/${THE_FILE}
+      ${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}
+      SHOW_PROGRESS
+      STATUS status
+      INACTIVITY_TIMEOUT 30
+      )
+    list(GET status 0 status_num)
+    if(NOT status_num EQUAL 0 OR NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}")
+      message(FATAL_ERROR "Could not download ${THE_FILE}")
+    endif()
+  endif()
+endfunction()
+
+# Some very small test files may be committed to the repo. This
+# function copies such a data file to the build directory.
 function(copy_test_data name)
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/${name}"
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 endfunction()
 
-# Create a test from a test source file.
+# This function builds, links, and runs a test program.
 function(create_test name g2_kind)
   add_executable(${name} ${name}.f90)
   target_link_libraries(${name} PRIVATE g2_test_lib ${g2_kind} PNG::PNG)
   add_test(${name} ${name})
 endfunction()
 
-# Copy test data files.
+# Get test data from the EMC FTP site.
+if(FTP_TEST_FILES)
+  set(G2_FTP_URL "https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-g2")
+  set(WW3_WEST_FILE "WW3_Regional_US_West_Coast_20220718_0000.grib2")
+  set(WW3_EAST_FILE "WW3_Regional_US_East_Coast_20220717_0600.grib2")
+  foreach(THE_FILE IN LISTS WW3_WEST_FILE WW3_EAST_FILE) 
+    PULL_DATA(${G2_FTP_URL} ${THE_FILE})
+  endforeach()
+endif()
+
+#copy test data files
 copy_test_data(testdata_g2grids)
 
-# These tests link to the g2_d library.
+# g2_d tests
 create_test(test_g2 g2_d)
 create_test(test_g2_encode g2_d)
 create_test(test_g2_decode g2_d)
@@ -46,10 +76,8 @@ create_test(test_g2grids g2_d)
 create_test(test_cmplxpack g2_d)
 create_test(test_mkieee g2_d)
 create_test(test_getlocal g2_d)
-create_test(test_putgb2 g2_d)
-create_test(test_realloc g2_d)
 
-# These tests link to the g2_4 library.
+# g2_4 tests
 create_test(test_simpack g2_4)
 create_test(test_gbytec g2_4)
 create_test(test_gribcreate g2_4)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 #copy test data files
 copy_test_data(testdata_g2grids)
 
-# g2_d tests
+# These tests link to the g2_d library.
 create_test(test_g2 g2_d)
 create_test(test_g2_encode g2_d)
 create_test(test_g2_decode g2_d)
@@ -77,7 +77,7 @@ create_test(test_cmplxpack g2_d)
 create_test(test_mkieee g2_d)
 create_test(test_getlocal g2_d)
 
-# g2_4 tests
+# These tests link to the g2_4 library.
 create_test(test_simpack g2_4)
 create_test(test_gbytec g2_4)
 create_test(test_gribcreate g2_4)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,8 @@ create_test(test_g2grids g2_d)
 create_test(test_cmplxpack g2_d)
 create_test(test_mkieee g2_d)
 create_test(test_getlocal g2_d)
+create_test(test_putgb2 g2_d)
+create_test(test_realloc g2_d)
 
 # These tests link to the g2_4 library.
 create_test(test_simpack g2_4)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,8 @@ function(create_test name g2_kind)
   add_test(${name} ${name})
 endfunction()
 
-# Get test data from the EMC FTP site.
+# If the user is running the tests on the data files from the EMC FTP
+# site, then get the files.
 if(FTP_TEST_FILES)
   set(G2_FTP_URL "https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-g2")
   set(WW3_WEST_FILE "WW3_Regional_US_West_Coast_20220718_0000.grib2")
@@ -55,7 +56,7 @@ if(FTP_TEST_FILES)
   endforeach()
 endif()
 
-#copy test data files
+# Copy test data files that are in the repo to the build directory.
 copy_test_data(testdata_g2grids)
 
 # These tests link to the g2_d library.


### PR DESCRIPTION
Fixes #263 

Allows build system to fetch test files from our FTP site.