### PR TITLE
changed some CI job names

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
     - develop
+    paths-ignore:
+    - README.md
   pull_request:
     branches:
     - develop
+    paths-ignore:
+    - README.md
 
 # Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
 # without having to do it in manually every step
@@ -14,7 +18,7 @@ defaults:
     shell: bash -leo pipefail {0}
 
 jobs:
-  intel:
+  Intel:
     runs-on: ubuntu-latest
     env:
       CC: icc

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -12,7 +12,7 @@ on:
     - README.md
 
 jobs:
-  macOS:
+  MacOS:
     runs-on: macos-latest
     env:
       FC: gfortran-12

--- a/src/putgb2.F90
+++ b/src/putgb2.F90
@@ -1,6 +1,7 @@
 !> @file
-!> @brief This subroutine read and unpack sections 6 and 7 from ah
-!> grib2 message.
+!> @brief Packs a single field into a GRIB2 message and
+!> writes out that message to the file.
+!>
 !> @author Stephen Gilbert @date 2002-01-11
 
 !> This subroutine packs a single field into a grib2 message and


### PR DESCRIPTION
Part of #331 

Some name changes to keep things consistent.

Changed the names of the Intel and MacOS CI jobs.

Also fixed documentation error.