### PR TITLE
added TEST_FILE_DIR option to CMake, cached test data in the developer build

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -1,6 +1,7 @@
 # This is a GitHub actions workflow for NCEPLIBS-g2.
 #
-# This builds the devleper branch with checking.
+# This builds the develop branch with documentation, warning check,
+# and address sanitizer.
 #
 # Ed Hartnett, 12/22/22
 name: developer 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -90,6 +90,13 @@ jobs:
       with:
         path: g2
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v2
+      with:
+        path: ~/data
+        key: data-1
+
     - name:  build
       run: |
         set -x
@@ -97,7 +104,7 @@ jobs:
         mkdir build
         doxygen --version
         cd build
-        cmake .. -DENABLE_DOCS=On -DJasper_ROOT=~/Jasper -DCMAKE_PREFIX_PATH="~/bacio;~/w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DFTP_TEST_FILES=ON -DCMAKE_BUILD_TYPE=Debug 
+        cmake .. -DENABLE_DOCS=On -DJasper_ROOT=~/Jasper -DCMAKE_PREFIX_PATH="~/bacio;~/w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_BUILD_TYPE=Debug 
         make -j2 VERBOSE=1
 
     - name: test
@@ -105,6 +112,12 @@ jobs:
         cd $GITHUB_WORKSPACE/g2/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null
+
+    - name: cache-data
+      if: steps.cache-data.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/data
+        cp $GITHUB_WORKSPACE/g2c/build/tests/*.grib2 ~/data
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v2

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -117,7 +117,7 @@ jobs:
       if: steps.cache-data.outputs.cache-hit != 'true'
       run: |
         mkdir ~/data
-        cp $GITHUB_WORKSPACE/g2c/build/tests/data/* ~/data
+        cp $GITHUB_WORKSPACE/g2/build/tests/data/* ~/data
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v2

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -117,7 +117,7 @@ jobs:
       if: steps.cache-data.outputs.cache-hit != 'true'
       run: |
         mkdir ~/data
-        cp $GITHUB_WORKSPACE/g2c/build/tests/*.grib2 ~/data
+        cp $GITHUB_WORKSPACE/g2c/build/tests/data/* ~/data
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ option(LOGGING "Turn on internal logging messages. Only useful to g2 developers.
 option(BUILD_4 "Build libg2_4.a" ON)
 option(BUILD_D "Build libg2_d.a" ON)
 
+# Developers can use this option to specify a local directory which
+# holds the test files. They will be copied instead of fetching the
+# files via FTP.
+SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
+message(STATUS "Finding test data files in directory ${TEST_FILE_DIR}.")
+
 # Set pre-processor symbol if logging is desired.
 if(LOGGING)
   add_definitions(-DLOGGING)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,16 @@ link_directories("/usr/local/lib")
 # site. This function is used to download such test data. It takes two
 # arguments, the URL and the file to be downloaded.
 function(PULL_DATA THE_URL THE_FILE)
+  # If the TEST_FILE_DIR was specified, look for our test data files
+  # there before FTPing them. Developers can keep all test files on
+  # their machines, and save the time of downloading them every time.
+  if(NOT ${TEST_FILE_DIR} STREQUAL ".")
+    if (EXISTS ${TEST_FILE_DIR}/${THE_FILE})
+      message(STATUS "Copying file ${TEST_FILE_DIR}/${THE_FILE} to test data directory.")
+      FILE(COPY ${TEST_FILE_DIR}/${THE_FILE}
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+  endif()
   if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}")
     file(DOWNLOAD
       ${THE_URL}/${THE_FILE}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,19 +17,19 @@ function(PULL_DATA THE_URL THE_FILE)
     if (EXISTS ${TEST_FILE_DIR}/${THE_FILE})
       message(STATUS "Copying file ${TEST_FILE_DIR}/${THE_FILE} to test data directory.")
       FILE(COPY ${TEST_FILE_DIR}/${THE_FILE}
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/data)
     endif()
   endif()
-  if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}")
+  if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${THE_FILE}")
     file(DOWNLOAD
       ${THE_URL}/${THE_FILE}
-      ${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}
+      ${CMAKE_CURRENT_BINARY_DIR}/data/${THE_FILE}
       SHOW_PROGRESS
       STATUS status
       INACTIVITY_TIMEOUT 30
       )
     list(GET status 0 status_num)
-    if(NOT status_num EQUAL 0 OR NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${THE_FILE}")
+    if(NOT status_num EQUAL 0 OR NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${THE_FILE}")
       message(FATAL_ERROR "Could not download ${THE_FILE}")
     endif()
   endif()

--- a/tests/test_getg2ir.F90
+++ b/tests/test_getg2ir.F90
@@ -27,7 +27,7 @@ program test_getg2ir
 
   ! Open a real GRIB2 file.
   print *, 'Indexing a real GRIB2 file...'
-  call baopenr(lugb, "WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
+  call baopenr(lugb, "data/WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
   if (iret .ne. 0) stop 100
 
   msk1 = 1000

--- a/tests/test_getgb2ir.F90
+++ b/tests/test_getgb2ir.F90
@@ -71,7 +71,7 @@ program test_ixgb2
 
   ! Now open a real GRIB2 file.
   print *, 'Indexing a real GRIB2 file...'
-  call baopenr(lugi, "WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
+  call baopenr(lugi, "data/WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
   if (iret .ne. 0) stop 100
 
   ! Skip the first 202 bytes of the test file.

--- a/tests/test_getgb2p.F90
+++ b/tests/test_getgb2p.F90
@@ -35,7 +35,7 @@ program test_getgb2p
 
   ! Open a real GRIB2 file.
   print *, 'Indexing a real GRIB2 file WW3_Regional_US_West_Coast_20220718_0000.grib2...'
-  call baopenr(lugb, "WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
+  call baopenr(lugb, "data/WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
   if (iret .ne. 0) stop 100
 
   lugi = 0

--- a/tests/test_getgb2r.F90
+++ b/tests/test_getgb2r.F90
@@ -71,7 +71,7 @@ program test_ixgb2
 
   ! Now open a real GRIB2 file.
   print *, 'Indexing a real GRIB2 file...'
-  call baopenr(lugi, "WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
+  call baopenr(lugi, "data/WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
   if (iret .ne. 0) stop 100
 
   ! Skip the first 202 bytes of the test file.

--- a/tests/test_getgb2s.F90
+++ b/tests/test_getgb2s.F90
@@ -50,7 +50,7 @@ program test_getgb2s
 
   ! Open a real GRIB2 file.
   print *, 'Indexing a real GRIB2 file WW3_Regional_US_West_Coast_20220718_0000.grib2...'
-  call baopenr(lugb, "WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
+  call baopenr(lugb, "data/WW3_Regional_US_West_Coast_20220718_0000.grib2", iret)
   if (iret .ne. 0) stop 100
 
   ! Get the index information for the GRIB2 file.

--- a/tests/test_getidx.F90
+++ b/tests/test_getidx.F90
@@ -9,7 +9,7 @@ program test_getidx
 
   ! THese are the test files we will use.
   character(*) :: TEST_FILE_WW3_WEST
-  parameter (TEST_FILE_WW3_WEST = 'WW3_Regional_US_West_Coast_20220718_0000.grib2')
+  parameter (TEST_FILE_WW3_WEST = 'data/WW3_Regional_US_West_Coast_20220718_0000.grib2')
   character(*) :: TEST_FILE_GDAS
   parameter (TEST_FILE_GDAS = 'gdaswave.t00z.wcoast.0p16.f000.grib2')
   character(*) :: TEST_FILE_GDAS_INDEX

--- a/tests/test_ixgb2.F90
+++ b/tests/test_ixgb2.F90
@@ -8,7 +8,7 @@ program test_ixgb2
   implicit none
 
   character(*) :: TEST_FILE_WW3_WEST
-  parameter (TEST_FILE_WW3_WEST = 'WW3_Regional_US_West_Coast_20220718_0000.grib2')
+  parameter (TEST_FILE_WW3_WEST = 'data/WW3_Regional_US_West_Coast_20220718_0000.grib2')
   integer :: lugi = 3
   character(len=1), pointer, dimension(:) :: cbuf(:)
   character :: expected_cbuf(200)

--- a/tests/test_skgb.F90
+++ b/tests/test_skgb.F90
@@ -9,7 +9,7 @@ program test_skgb
 
   ! THese are the test files we will use.
   character(*) :: TEST_FILE_WW3_WEST
-  parameter (TEST_FILE_WW3_WEST = 'WW3_Regional_US_West_Coast_20220718_0000.grib2')
+  parameter (TEST_FILE_WW3_WEST = 'data/WW3_Regional_US_West_Coast_20220718_0000.grib2')
   character(*) :: TEST_FILE_GDAS
   parameter (TEST_FILE_GDAS = 'gdaswave.t00z.wcoast.0p16.f000.grib2')
   character(*) :: TEST_FILE_GDAS_INDEX


### PR DESCRIPTION
Added TEST_FILE_DIR option, so that test files can be cached. Added caching for the test files to the developer workflow.

Part of #411