### PR TITLE
made memory checking more strict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 add_subdirectory(src)
 
 # This will cause the memcheck to fail if memory problems are found.
-set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1")
+set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1 --errors-for-leak-kinds=all")
 
 # Turn on unit testing.
 include(CTest)

--- a/src/getidx.F90
+++ b/src/getidx.F90
@@ -14,12 +14,12 @@
 !> is less than zero, then the index is re-read from index file
 !> abs(lugi).
 !>
-!> @note The file unit numbers must be in range 0 - 9999.
+!> @note The file unit numbers must be in range 1 - 9999.
 !>
 !> @param[in] lugb integer unit of the GRIB2 data file.
 !> File must have been opened with [baopen() or baopenr()]
 !> (https://noaa-emc.github.io/NCEPLIBS-bacio/) before calling
-!> this routine.
+!> this routine. If 0, then all saved memory will be released.
 !> @param[in] lugi integer unit of the GRIB2 index file.
 !> If nonzero, file must have been opened with [baopen() or baopenr()]
 !> (https://noaa-emc.github.io/NCEPLIBS-bacio/) before


### PR DESCRIPTION
Fixes #470 

Stricter memory checking. This now ensures that tests cannot leak memory.

This is expected to fail until some additional leaks are cleaned up.