### PR TITLE
turned off debug build in Linux_versions workflow

### DIFF
--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -136,7 +136,7 @@ jobs:
         cd g2
         mkdir build
         cd build
-        cmake -DCMAKE_PREFIX_PATH="~/jasper;~/g2c;~/bacio;~/w3emc" -DLOGGING=ON -DCMAKE_BUILD_TYPE=Debug -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data ..
+        cmake -DCMAKE_PREFIX_PATH="~/jasper;~/g2c;~/bacio;~/w3emc" -DLOGGING=ON -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data ..
         make -j2 VERBOSE=1
 
     - name: cache-data


### PR DESCRIPTION
Fixes #333 

Turning off debug in the Linux_versions workflow to ensure it works in the way most users will be using it. Debug is still built in the developer workflow and some of the Linux_options builds.

