### PR TITLE
Ensure CI tests are run in Spack.yml

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -20,17 +20,17 @@ jobs:
   Spack:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest"]
         pic: ["+pic", "~pic"]
         precision: ["precision=d", "precision=4"]
         w3emc: ["+w3emc", "~w3emc"]
     runs-on: ${{ matrix.os }}
 
     steps:
-    
+
     - name: checkout-g2
       uses: actions/checkout@v4
-      with: 
+      with:
         path: g2
 
     - name: spack-build-and-test
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    
+
     - name: checkout-g2
       uses: actions/checkout@v4
-      with: 
+      with:
         path: g2
 
     - name: recipe-check

--- a/spack/package.py
+++ b/spack/package.py
@@ -62,3 +62,7 @@ class G2(CMakePackage):
             lib = find_libraries("libg2_" + suffix, root=self.prefix, shared=False, recursive=True)
             env.set("G2_LIB" + suffix, lib[0])
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
It turns out there are ways that Spack's built-in ctest facilities can quietly fail, so these changes ensure that "make test" will be run, and specifically that the CI will fail if the test target cannot be found. I'm also taking out macos from Spack.yml because for some reason the tests aren't running (I'm seeing this in other packages too), so I need to investigate further.

Addresses #553 (addendum to #556)