### PR TITLE
stop trying to set max mem usage for jasper

### DIFF
--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -139,7 +139,7 @@ enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
     /* static jas_std_allocator_t allocator; */
     /* jas_std_allocator_init(&allocator); */
     /* jas_conf_set_allocator(JAS_CAST(jas_std_allocator_t *, &allocator)); */
-    jas_conf_set_max_mem_usage(10000000);
+    /* jas_conf_set_max_mem_usage(10000000); */
     jas_conf_set_multithread(true);
     if (jas_init_library())
         return G2_JASPER_INIT;


### PR DESCRIPTION
Taking out the jasper initialization of max memory to try and resolve https://github.com/NOAA-EMC/NCEPLIBS-grib_util/issues/273