### PR TITLE
Make jasper max memory configurable by env var

### DIFF
--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -43,6 +43,7 @@ int_dec_jpeg2000(char *injpc, g2int bufsize, void *outfld, int out_is_g2int)
     char *opts = NULL;
     jas_matrix_t *data;
     int fmt;
+    char *g2jaspermaxmem;
 
     /* Initialize Jasper. */
 #ifdef JASPER3
@@ -50,7 +51,10 @@ int_dec_jpeg2000(char *injpc, g2int bufsize, void *outfld, int out_is_g2int)
     /* static jas_std_allocator_t allocator; */
     /* jas_std_allocator_init(&allocator); */
     /* jas_conf_set_allocator(JAS_CAST(jas_std_allocator_t *, &allocator)); */
-    jas_conf_set_max_mem_usage(10000000);
+    if (( g2jaspermaxmem = getenv("G2_JASPER_MAXMEM")) != NULL )
+        jas_conf_set_max_mem_usage(atoi(g2jaspermaxmem));
+    else
+        jas_conf_set_max_mem_usage(1073741824);
     jas_conf_set_multithread(true);
     if (jas_init_library())
         return G2_JASPER_INIT;

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -98,6 +98,7 @@ enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
     jas_image_cmpt_t cmpt, *pcmpt;
     char opts[MAXOPTSSIZE];
     int fmt;
+    char *g2jaspermaxmem;
 
     /* Set lossy compression options, if requested. */
     if (ltype != 1)
@@ -139,7 +140,10 @@ enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
     /* static jas_std_allocator_t allocator; */
     /* jas_std_allocator_init(&allocator); */
     /* jas_conf_set_allocator(JAS_CAST(jas_std_allocator_t *, &allocator)); */
-    /* jas_conf_set_max_mem_usage(10000000); */
+    if (( g2jaspermaxmem = getenv("G2_JASPER_MAXMEM")) != NULL )
+        jas_conf_set_max_mem_usage(atoi(g2jaspermaxmem));
+    else
+        jas_conf_set_max_mem_usage(1073741824);
     jas_conf_set_multithread(true);
     if (jas_init_library())
         return G2_JASPER_INIT;


### PR DESCRIPTION
@edwardhartnett here's what I was thinking for setting the jasper max mem to deal with the [grib-util issue](https://github.com/NOAA-EMC/NCEPLIBS-grib_util/issues/273) you were running into. Here, the the default is set to the [jasper default](https://github.com/jasper-software/jasper/blob/master/CMakeLists.txt), but allow it to be configured by an environment variable. If this looks ok I can update documentation.