### PR TITLE
Ci debug 25sep

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -49,6 +49,14 @@ jobs:
         # Run 'spack load' to check for obvious errors in setup_run_environment
         spack load g2
 
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: test-output
+        path: /home/runner/work/NCEPLIBS-g2/NCEPLIBS-g2/g2/spack-build-*/Testing/Temporary/LastTest.log
+
+
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
+      if: ${{ always() }}
       with:
         name: spackci-test-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
         path: ${{ github.workspace }}/g2/spack-build-*/Testing/Temporary/LastTest.log

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -54,7 +54,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: spackci-test-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
-        path: ${{ env.GITHUB_WORKSPACE }}/g2/spack-build-*/Testing/Temporary/LastTest.log
+        path: ${{ github.workspace }}/g2/spack-build-*/Testing/Temporary/LastTest.log
 
 
   # This job validates the Spack recipe by making sure each cmake build option is represented

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v3
-      if: ${{ always() }}
+      if: ${{ failure() }}
       with:
         name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
         path: ${{ github.workspace }}/g2/spack-build-*/Testing/Temporary/LastTest.log

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: spackci-test-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
         path: ${{ github.workspace }}/g2/spack-build-*/Testing/Temporary/LastTest.log
 
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -53,8 +53,8 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
-        name: test-output
-        path: /home/runner/work/NCEPLIBS-g2/NCEPLIBS-g2/g2/spack-build-*/Testing/Temporary/LastTest.log
+        name: spackci-test-output-${{ matrix.os }}-${{ matrix.pic }}-${{ matrix.precision }}-${{ matrix.w3emc }}
+        path: ${{ env.GITHUB_WORKSPACE }}/g2/spack-build-*/Testing/Temporary/LastTest.log
 
 
   # This job validates the Spack recipe by making sure each cmake build option is represented


### PR DESCRIPTION
@edwardhartnett try adding this (it's probably a good idea to add something similar for our other Spack-based workflows). In my test just now, the output was:
```
34/34 Testing: run_jasper_warning_test.sh
34/34 Test: run_jasper_warning_test.sh
Command: "/usr/bin/bash" "run_jasper_warning_test.sh"
Directory: /home/runner/work/NCEPLIBS-g2/NCEPLIBS-g2/g2/spack-build-cb46paq/tests
"run_jasper_warning_test.sh" start time: Sep 25 15:24 UTC
Output:
----------------------------------------------------------

*** Running jasper warning test
+ ls -l test_jpcpack_4
ls: cannot access 'test_jpcpack_4': No such file or directory
<end of output>
Test time =   0.00 sec
----------------------------------------------------------
Test Failed.
"run_jasper_warning_test.sh" end time: Sep 25 15:24 UTC
"run_jasper_warning_test.sh" time elapsed: 00:00:00
----------------------------------------------------------

End testing: Sep 25 15:24 UTC
```