### PR TITLE
handling reading bytes into reals

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         find /Library/Frameworks/ -name "png*"
         sudo rm -rf /Library/Frameworks/Mono.framework
-        brew update
+        #brew update
         brew install libpng
         brew install jpeg-turbo
 

--- a/src/g2bytes.F90
+++ b/src/g2bytes.F90
@@ -55,7 +55,7 @@ end subroutine g2_gbytec1
 !> packed bit string.
 !>
 !> @param[in] in array input
-!> @param[out] iout unpacked array output
+!> @param[out] rout unpacked array output
 !> @param[in] iskip initial number of bits to skip
 !> @param[in] nbits Number of bits of each real in IN to take. Must
 !> be 32.

--- a/src/g2bytes.F90
+++ b/src/g2bytes.F90
@@ -270,7 +270,7 @@ end subroutine g2_sbytec1
 !> Put real values into a packed bit string in big-endian order.
 !>
 !> @param[out] out Packed character array output.
-!> @param[in] in real array input.
+!> @param[in] rin real array input.
 !> @param[in] iskip Initial number of bits to skip.
 !> @param[in] nbits Number of bits of each integer in OUT to
 !> fill. Must be 32.

--- a/src/g2bytes.F90
+++ b/src/g2bytes.F90
@@ -267,12 +267,36 @@ subroutine g2_sbytec1(out, in, iskip, nbits)
   call g2_sbytesc(out, ain, iskip, nbits, 0, 1)
 end subroutine g2_sbytec1
 
-!> Put arbitrary size (up to 32 bits each) values into a packed bit
-!> string, taking the low order bits from each value in the unpacked
-!> array.
+!> Put real values into a packed bit string in big-endian order.
 !>
-!> @param[out] out Packed array output.
-!> @param[in] in Unpacked array input.
+!> @param[out] out Packed character array output.
+!> @param[in] in real array input.
+!> @param[in] iskip Initial number of bits to skip.
+!> @param[in] nbits Number of bits of each integer in OUT to
+!> fill. Must be 32.
+!> @param[in] nskip Additional number of bits to skip on each iteration.
+!> @param[in] n Number of iterations.
+!>
+!> @author Stephen Gilbert @date 2004-04-27
+subroutine g2_sbytescr(out, rin, iskip, nbits, nskip, n)
+  implicit none
+  character*1, intent(out) :: out(*)
+  real, intent(in) :: rin(n)
+  integer, intent(in) :: iskip, nbits, nskip, n
+  integer :: in(n)
+
+  ! Transfer real array to integer array.
+  in(1:n) = transfer(rin, in(1:n), n)
+
+  ! Pack into character array.
+  call g2_sbytesc(out, in, iskip, nbits, nskip, n)
+end subroutine g2_sbytescr
+
+!> Put arbitrary size (up to 32 bits each) integer values
+!> into a packed bit string in big-endian order.
+!>
+!> @param[out] out Packed character array output.
+!> @param[in] in Integer array input.
 !> @param[in] iskip Initial number of bits to skip.
 !> @param[in] nbits Number of bits of each integer in OUT to
 !> fill. Must be 32 or less.

--- a/src/g2bytes.F90
+++ b/src/g2bytes.F90
@@ -51,15 +51,16 @@ subroutine g2_gbytec1(in, siout, iskip, nbits)
   siout = iout(1)
 end subroutine g2_gbytec1
 
-!> Extract arbitrary size big-endian floating-point values (32 bits
-!> each) from a packed bit string.
+!> Extract big-endian floating-point values (32 bits each) from a
+!> packed bit string.
 !>
 !> @param[in] in array input
 !> @param[out] iout unpacked array output
 !> @param[in] iskip initial number of bits to skip
 !> @param[in] nbits Number of bits of each real in IN to take. Must
 !> be 32.
-!> @param[in] nskip Additional number of bits to skip on each iteration.
+!> @param[in] nskip Additional number of bits to skip on each
+!iteration.
 !> @param[in] n Number of floats to extract.
 !>
 !> @author Stephen Gilbert @date 2004-04-27

--- a/src/g2bytes.F90
+++ b/src/g2bytes.F90
@@ -26,8 +26,8 @@ subroutine g2_gbytec(in, iout, iskip, nbits)
   call g2_gbytesc(in, iout, iskip, nbits, 0, 1)
 end subroutine g2_gbytec
 
-!> Extract one arbitrary size big-endian value (up to 32 bits) from a
-!> packed bit string into a scalar integer.
+!> Extract one arbitrary size big-endian integer value (up to 32 bits)
+!> from a packed bit string into a scalar integer.
 !>
 !> This should be used converting one integer*4 value. If more values
 !> need to be converted, use g2_sbytesc().
@@ -51,8 +51,34 @@ subroutine g2_gbytec1(in, siout, iskip, nbits)
   siout = iout(1)
 end subroutine g2_gbytec1
 
-!> Extract arbitrary size values (up to 32 bits each) from a packed
-!> bit string, right justifying each value in the unpacked array.
+!> Extract arbitrary size big-endian floating-point values (32 bits
+!> each) from a packed bit string.
+!>
+!> @param[in] in array input
+!> @param[out] iout unpacked array output
+!> @param[in] iskip initial number of bits to skip
+!> @param[in] nbits Number of bits of each real in IN to take. Must
+!> be 32.
+!> @param[in] nskip Additional number of bits to skip on each iteration.
+!> @param[in] n Number of floats to extract.
+!>
+!> @author Stephen Gilbert @date 2004-04-27
+subroutine g2_gbytescr(in, rout, iskip, nbits, nskip, n)
+  implicit none
+  character*1, intent(in) :: in(*)
+  real (kind = 4), intent(out) :: rout(*)
+  integer, intent(in) :: iskip, nbits, nskip, n
+  integer (kind = 4) :: iout(n)
+
+  ! Unpack into integer array.
+  call g2_gbytesc(in, iout, iskip, nbits, nskip, n)
+
+  ! Transfer to real array.
+  rout(1:n) = transfer(iout, rout(1:n), n)
+end subroutine g2_gbytescr
+
+!> Extract arbitrary size big-endian integer values (up to 32 bits
+!> each) from a packed bit string.
 !>
 !> @param[in] in array input
 !> @param[out] iout unpacked array output
@@ -415,7 +441,7 @@ end subroutine g2_sbytesc8
 !> @param[in] num Number of floating point values to convert.
 !>
 !> @author Stephen Gilbert @date 2000-05-09
-subroutine rdieee(rieee,a,num)
+subroutine rdieee(rieee, a, num)
   implicit none
   
   real(4), intent(in) :: rieee(num)

--- a/src/g2create.F90
+++ b/src/g2create.F90
@@ -350,8 +350,8 @@ subroutine addfield(cgrib,lcgrib,ipdsnum,ipdstmpl,ipdstmplen, &
         coordlist_4(i) = real(coordlist(i), 4)
      end do
      call mkieee(coordlist_4, coordieee, numcoord)
-     call g2_sbytesc(cgrib,coordieee,iofst,32,0,numcoord)
-     iofst=iofst+(32*numcoord)
+     call g2_sbytesc(cgrib, coordieee, iofst, 32, 0, numcoord)
+     iofst = iofst + (32 * numcoord)
   endif
 
   ! Calculate length of section 4 and store it in octets

--- a/src/g2create.F90
+++ b/src/g2create.F90
@@ -350,7 +350,7 @@ subroutine addfield(cgrib,lcgrib,ipdsnum,ipdstmpl,ipdstmplen, &
         coordlist_4(i) = real(coordlist(i), 4)
      end do
      call mkieee(coordlist_4, coordieee, numcoord)
-     call g2_sbytesc(cgrib, coordieee, iofst, 32, 0, numcoord)
+     call g2_sbytescr(cgrib, coordieee, iofst, 32, 0, numcoord)
      iofst = iofst + (32 * numcoord)
   endif
 

--- a/src/g2get.F90
+++ b/src/g2get.F90
@@ -976,7 +976,7 @@ subroutine unpack4(cgrib, lcgrib, iofst, ipdsnum, ipdstmpl, &
   !     Definition Template, if necessary.
   if (numcoord .ne. 0) then
      allocate (coordieee(numcoord))
-     call g2_gbytesc(cgrib, coordieee, iofst, 32, 0, numcoord)
+     call g2_gbytescr(cgrib, coordieee, iofst, 32, 0, numcoord)
      call rdieee(coordieee, coordlist, numcoord)
      deallocate (coordieee)
      iofst = iofst + (32*numcoord)

--- a/src/g2unpack.F90
+++ b/src/g2unpack.F90
@@ -430,7 +430,7 @@ subroutine gf_unpack4(cgrib, lcgrib, iofst, ipdsnum, ipdstmpl, &
         if (allocated(coordieee)) deallocate(coordieee)
         return
      endif
-     call g2_gbytesc(cgrib, coordieee, iofst, 32, 0, numcoord)
+     call g2_gbytescr(cgrib, coordieee, iofst, 32, 0, numcoord)
      call rdieee(coordieee, coordlist, numcoord)
      deallocate (coordieee)
      iofst = iofst + (32 * numcoord)

--- a/tests/test_gbytec2.F90
+++ b/tests/test_gbytec2.F90
@@ -101,6 +101,34 @@ program test_gbytec2
   if (r2(1) .ne. 1.0 .or. r2(2) .ne. 1.0) stop 110
   print *, 'OK!'
   
+  print *, 'testing g2_sbytescr() with a single float...'
+  ! Reset array.
+  do i = 1, 4
+     c4(i) = '.'
+  end do
+  r1(1) = 1.0
+  call g2_sbytescr(c4, r1, 0, 32, 0, 1)
+  if (ichar(c4(1)) .ne. 63 .or. ichar(c4(2)) .ne. 128 .or. ichar(c4(3)) .ne. 0 .or. &
+       ichar(c4(4)) .ne. 0) stop 120
+  print *, 'OK!'
+
+  print *, 'testing g2_sbytescr() with a two floats...'
+  ! Reset array.
+  do i = 1, 8
+     c8(i) = '.'
+  end do
+  r2(1) = 1.0
+  r2(2) = 1.0
+  call g2_sbytescr(c8, r2, 0, 32, 0, 2)
+  ! do i = 1, 8
+  !    print '(z2.2)', c8(i)
+  ! end do
+  do i = 0, 1
+     if (ichar(c8(1 + i * 4)) .ne. 63 .or. ichar(c8(2 + i * 4)) .ne. 128 .or. &
+          ichar(c8(3 + i * 4)) .ne. 0 .or. ichar(c8(4 + i * 4)) .ne. 0) stop 130
+  end do
+  print *, 'OK!'
+
   print *, 'SUCCESS!'
 
 end program test_gbytec2

--- a/tests/test_gbytec2.F90
+++ b/tests/test_gbytec2.F90
@@ -8,8 +8,10 @@ program test_gbytec2
 
   character (len = 1) :: c1(1) = 'a'
   character (len = 1) :: c4(4), c4_2(4)
+  character (len = 1) :: c8(8)
   integer (kind = 4) :: i1
   integer :: i
+  real (kind = 4) :: r1(1), r2(2)
 
   ! Initialize some test data.
   do i = 1, 4
@@ -76,6 +78,29 @@ program test_gbytec2
   if (any(c4 .ne. c4_2)) stop 25
 
   print *, 'OK!'
+  
+  print *, 'testing g2_gbytescr() with a single float...'
+  ! Reset array to IEEE float value 1.0.
+  c4(1) = char(63)
+  c4(2) = char(128)
+  c4(3) = char(0)
+  c4(4) = char(0)
+  call g2_gbytescr(c4, r1, 0, 32, 0, 1)
+  if (r1(1) .ne. 1.0) stop 100
+  print *, 'OK!'
+  
+  print *, 'testing g2_gbytescr() with a two floats...'
+  ! Reset array to IEEE float value 1.0, twice.
+  do i = 0, 1
+     c8(1 + i * 4) = char(63)
+     c8(2 + i * 4) = char(128)
+     c8(3 + i * 4) = char(0)
+     c8(4 + i * 4) = char(0)
+  end do
+  call g2_gbytescr(c8, r2, 0, 32, 0, 2)
+  if (r2(1) .ne. 1.0 .or. r2(2) .ne. 1.0) stop 110
+  print *, 'OK!'
+  
   print *, 'SUCCESS!'
 
 end program test_gbytec2


### PR DESCRIPTION
Fixes #583 

Added subroutines to pack/unpack reals into character arrays in big-endian order.

This will allow for the elimination of some warnings.