### PR TITLE
Add getgb2p2 to g2getgb2.F90 (RRFS/tocgrib2 support) - DO NOT MERGE

### DIFF
--- a/src/g2getgb2.F90
+++ b/src/g2getgb2.F90
@@ -580,6 +580,184 @@ subroutine getgb2p(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt,  &
   call gf_free(gfld)
 end subroutine getgb2p
 
+!> Find and extract a GRIB2 message from a file with idxver=2.
+!>
+!> This subroutine reads a GRIB index file (or optionally the GRIB
+!> file itself) to get the index buffer (i.e. table of contents) for
+!> the GRIB file. It finds in the index buffer a reference to the
+!> GRIB field requested.
+!>
+!> The GRIB field request specifies the number of fields to skip and
+!> the unpacked identification section, grid definition template and
+!> product defintion section parameters. (A requested parameter of
+!> -9999 means to allow any value of this parameter to be found.)
+!>
+!> If the requested GRIB field is found, then it is read from the GRIB
+!> file and unpacked. If the GRIB field is not found, then the return
+!> code will be nonzero.
+!>
+!> The derived type @ref grib_mod::gribfield contains allocated memory
+!> that must be freed by the caller with subroutine gf_free().
+!>
+!> @note Specifing an index file may increase speed.
+!> Do not engage the same logical unit from more than one processor.
+!>
+!> @param[in] lugb Unit of the unblocked GRIB data file. The
+!> file must have been opened with [baopen() or baopenr()]
+!> (https://noaa-emc.github.io/NCEPLIBS-bacio/) before calling this
+!> routine.
+!> @param[in] lugi Unit of the unblocked GRIB index file. If
+!> nonzero, file must have been opened with [baopen() or baopenr()]
+!> (https://noaa-emc.github.io/NCEPLIBS-bacio/) before calling this
+!> subroutine. Set to 0 to get index buffer from the GRIB file.
+!> @param[in] j Number of fields to skip (set to 0 to search
+!> from beginning).
+!> @param[in] jdisc GRIB2 discipline number of requested field. See
+!> [GRIB2 - TABLE 0.0 -
+!> DISCIPLINE](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table0-0.shtml).
+!> Use -1 to accept any discipline.
+!> @param[in] jids Array of values in the identification
+!> section. (Set to -9999 for wildcard.)
+!> - jids(1) Identification of originating centre. See [TABLE 0 -
+!>   NATIONAL/INTERNATIONAL ORIGINATING
+!>   CENTERS](https://www.nco.ncep.noaa.gov/pmb/docs/on388/table0.html).
+!> - jids(2) Identification of originating sub-centre. See [TABLE C -
+!>   NATIONAL
+!>   SUB-CENTERS](https://www.nco.ncep.noaa.gov/pmb/docs/on388/tablec.html).
+!> - jids(3) GRIB master tables version number. See [GRIB2 - TABLE 1.0
+!>   - GRIB Master Tables Version
+!>   Number](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-0.shtml).
+!> - jids(4) GRIB local tables version number. See [GRIB2 - TABLE 1.1
+!>   - GRIB Local Tables Version
+!>   Number](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-1.shtml).
+!> - jids(5) Significance of reference time. See [GRIB2 - TABLE 1.2 -
+!>   Significance of Reference
+!>   Time](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-2.shtml).
+!> - jids(6) year (4 digits)
+!> - jids(7) month
+!> - jids(8) day
+!> - jids(9) hour
+!> - jids(10) minute
+!> - jids(11) second
+!> - jids(12) Production status of processed data. See [GRIB2 - TABLE
+!>   1.3 - Production Status of
+!>   Data](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-3.shtml).
+!> - jids(13) Type of processed data. See [GRIB2 - TABLE 1.4 - TYPE OF
+!>   DATA](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-4.shtml).
+!> @param[in] jpdtn Product Definition Template (PDT) number (n)
+!> (if = -1, don't bother matching PDT - accept any)
+!> @param[in] jpdt Array of values defining the Product Definition
+!> Template of the field for which to search (=-9999 for wildcard).
+!> @param[in] jgdtn Grid Definition Template (GDT) number (if = -1,
+!> don't bother matching GDT - accept any).
+!> @param[in] jgdt array of values defining the Grid Definition
+!> Template of the field for which to search (=-9999 for wildcard).
+!> @param[in] extract value indicating whether to return a
+!> GRIB2 message with just the requested field, or the entire
+!> GRIB2 message containing the requested field.
+!> - .true. return GRIB2 message containing only the requested field.
+!> - .false. return entire GRIB2 message containing the requested field.
+!> @param[out] k field number unpacked.
+!> @param[out] gribm returned GRIB message.
+!> @param[out] leng length of returned GRIB message in bytes.
+!> @param[out] iret integer return code
+!> - 0 No error.
+!> - 96 Error reading index.
+!> - 97 Error reading GRIB file.
+!> - 99 Request not found.
+!>
+!> @author Mark Iredell @date 1994-04-01
+subroutine getgb2p2(lugb, lugi, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt,  &
+     extract, k, gribm, leng, iret)
+  use grib_mod
+  implicit none
+
+  integer, intent(in) :: lugb, lugi, j, jdisc, jpdtn, jgdtn
+  integer, dimension(:) :: jids(*), jpdt(*), jgdt(*)
+  logical, intent(in) :: extract
+  integer, intent(out) :: k, iret, leng
+  character(len = 1), pointer, dimension(:) :: gribm
+
+  type(gribfield) :: gfld
+  integer :: irgi, irgs, jk, lpos, mskp, nlen, nmess, nnum, idxver
+  integer(kind = 8) :: msk1, msk2
+
+  character(len = 1), pointer, dimension(:) :: cbuf
+  parameter(msk1 = 32000, msk2 = 4000)
+
+  ! Declare interfaces (required for cbuf pointer).
+  interface
+     subroutine getg2i2(lugi, cbuf, idxver, nlen, nnum, iret)
+       integer, intent(in) :: lugi
+       character(len=1), pointer, dimension(:) :: cbuf
+       integer, intent(out) :: idxver, nlen, nnum, iret
+     end subroutine getg2i2
+     subroutine getg2i2r(lugb, msk1, msk2, mnum, idxver, cbuf, &
+          nlen, nnum, nmess, iret)
+       integer, intent(in) :: lugb
+       integer (kind = 8), intent(in) :: msk1, msk2
+       integer, intent(in) :: mnum, idxver
+       character(len = 1), pointer, dimension(:) :: cbuf
+       integer, intent(out) :: nlen, nnum, nmess, iret
+     end subroutine getg2i2r
+     subroutine getgb2s2(cbuf, idxver, nlen, nnum, j, jdisc, jids, jpdtn, jpdt, jgdtn, &
+          jgdt, k, gfld, lpos, iret)
+       import gribfield
+       character(len = 1), intent(in) :: cbuf(nlen)
+       integer, intent(in) :: idxver, nlen, nnum, j, jdisc
+       integer, dimension(:) :: jids(*)
+       integer, intent(in) :: jpdtn
+       integer, dimension(:) :: jpdt(*)
+       integer, intent(in) :: jgdtn
+       integer, dimension(:) :: jgdt(*)
+       integer, intent(out) :: k
+       type(gribfield), intent(out) :: gfld
+       integer, intent(out) :: lpos, iret
+     end subroutine getgb2s2
+     subroutine getgb2rp2(lugb, idxver, cindex, extract, gribm, leng, iret)
+       integer, intent(in) :: lugb, idxver
+       character(len = 1), intent(in) :: cindex(*)
+       logical, intent(in) :: extract
+       character(len = 1), pointer, dimension(:) :: gribm
+       integer, intent(out) :: leng, iret
+     end subroutine getgb2rp2
+  end interface
+
+  ! Initialize the index information in cbuf.
+  irgi = 0
+  if (lugi .gt. 0) then
+     call getg2i2(lugi, cbuf, idxver, nlen, nnum, irgi)
+  elseif (lugi .le. 0) then
+     mskp = 0
+     call getg2i2r(lugb, msk1, msk2, mskp, 2, cbuf, nlen, nnum, nmess, irgi)
+  endif
+  if (irgi .gt. 1) then
+     iret = 96
+     return
+  endif
+
+  ! Find info from index and fill a grib_mod::gribfield variable.
+  call getgb2s2(cbuf, 2, nlen, nnum, j, jdisc, jids, jpdtn, jpdt, jgdtn, jgdt,  &
+       jk, gfld, lpos, irgs)
+
+  if (irgs .ne. 0) then
+     iret = 99
+     call gf_free(gfld)
+     return
+  endif
+
+  ! Extract grib message from file.
+  nullify(gribm)
+  call getgb2rp2(lugb, 2, cbuf(lpos:), .false., gribm, leng, iret)
+
+  k = jk
+
+  ! Free cbuf memory allocated in getg2i/getg2ir().
+  if (associated(cbuf)) deallocate(cbuf)
+
+  call gf_free(gfld)
+end subroutine getgb2p2
+
 !> Read and unpack sections 6 and 7 from a GRIB2 message using a
 !> version 1 index record.
 !>


### PR DESCRIPTION
This PR adds a idxver=2 equivalent of the getgb2p subroutine, called getgb2p2.

Success so far: Using the modified tocgrib2 I can get it to write all 336 messages that have a match in the input namelist for https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-g2/rrfs.t12z.prslevfaa.f010.na3km.grib2 (namelist: https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-g2/grib2.awips.rrfs.010)

Outstanding problem: For messages with extract=.true. in the input namelist (U & V winds) the messages are missing 7777 at the end. I am still investigating the source of this.