### PR TITLE
Add 7777 test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ if(FTP_TEST_FILES)
       create_test(test_fv3 ${kind})
       create_test(test_create_index_fv3 ${kind})
       create_test(test_files_fv3 ${kind})
+      create_test(test_getgb2p_2 ${kind})
     endif()
     if(FTP_EXTRA_TEST_FILES)    
       create_test(test_create_index_gfsprs ${kind})
@@ -189,7 +190,6 @@ foreach(kind ${kinds})
   create_test(test_gettemplates ${kind})
   create_test(test_addfield ${kind})
   create_test(test_gf_unpack2 ${kind})
-  create_test(test_getgb2p_2 ${kind})
 
   # This test depends on gdt2gds(), which is not present if the GRIB1
   # library is not also included in the build.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ foreach(kind ${kinds})
   create_test(test_gettemplates ${kind})
   create_test(test_addfield ${kind})
   create_test(test_gf_unpack2 ${kind})
+  create_test(test_getgb2p_2 ${kind})
 
   # This test depends on gdt2gds(), which is not present if the GRIB1
   # library is not also included in the build.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,7 +91,7 @@ if(FTP_TEST_FILES)
 
   # User may also ask for large test file.
   if(FTP_LARGE_TEST_FILES)
-    set(FTP_FILES ${FTP_FILES} fv3lam.t00z.prslev.f000.grib2)
+    set(FTP_FILES ${FTP_FILES} fv3lam.t00z.prslev.f000.grib2 rrfs.t12z.prslevfaa.f010.na3km.grib2 grib2.awips.rrfs.010)
   endif()
 
   # User may also ask for extra large test files.

--- a/tests/test_getgb2p_2.F90
+++ b/tests/test_getgb2p_2.F90
@@ -63,7 +63,7 @@ PROGRAM test_getgb2p_2
   iret=0
   nrec = 0
   open(12, file='data/grib2.awips.rrfs.010')
-  foreachinputrecord: do
+  !foreachinputrecord: do
 
      !  Set Namelist defaults
      DSCPL=-1     ! Grib2 Discipline number
@@ -118,6 +118,6 @@ PROGRAM test_getgb2p_2
      c7=gribm(size(gribm)-1)
      d7=gribm(size(gribm))
      if(.not.all((/a7,b7,c7,d7/).eq.'7')) stop 77
-  enddo foreachinputrecord
+  !enddo foreachinputrecord
 
 END PROGRAM test_getgb2p_2

--- a/tests/test_getgb2p_2.F90
+++ b/tests/test_getgb2p_2.F90
@@ -63,7 +63,7 @@ PROGRAM test_getgb2p_2
   iret=0
   nrec = 0
   open(12, file='data/grib2.awips.rrfs.010')
-  !foreachinputrecord: do
+  foreachinputrecord: do
 
      !  Set Namelist defaults
      DSCPL=-1     ! Grib2 Discipline number
@@ -118,6 +118,7 @@ PROGRAM test_getgb2p_2
      c7=gribm(size(gribm)-1)
      d7=gribm(size(gribm))
      if(.not.all((/a7,b7,c7,d7/).eq.'7')) stop 77
-  !enddo foreachinputrecord
+    return
+  enddo foreachinputrecord
 
 END PROGRAM test_getgb2p_2

--- a/tests/test_getgb2p_2.F90
+++ b/tests/test_getgb2p_2.F90
@@ -10,17 +10,12 @@ PROGRAM test_getgb2p_2
   use gridtemplates
   integer,dimension(200) :: IDS,GDT,PDT
   integer   ::    DSCPL,GDTN,PDTN
-  integer   ::    nrec,mbul,dayofmonth,hourofday
-  integer,parameter :: lenhead=21,jrew=0
+  integer   ::    nrec
+  integer,parameter :: jrew=0
   character * 1 :: a7,b7,c7,d7
 
-  CHARACTER * 6   BULHED
   CHARACTER * 80  DESC,WMOHEAD
   CHARACTER * 200  fileb,filei,fileo
-  CHARACTER * 6   envvar
-  CHARACTER * 4   KWBX
-  CHARACTER * 1   CSEP(80)
-  CHARACTER * 1   WMOHDR(lenhead)
   character(len=1),pointer,dimension(:) :: gribm
 
   logical :: extract=.false.

--- a/tests/test_getgb2p_2.F90
+++ b/tests/test_getgb2p_2.F90
@@ -1,0 +1,128 @@
+! This test reads a large RRFS output file and runs the getgb2p subroutine for
+! each message. It verifies that the subroutine is correctly indexing the
+! lengths of each message section by verifying that the last four octets are
+! '7777'. 
+!
+! Alex Richert, May 2024
+PROGRAM test_getgb2p_2
+  use grib_mod
+  use pdstemplates
+  use gridtemplates
+  integer,dimension(200) :: IDS,GDT,PDT
+  integer   ::    DSCPL,GDTN,PDTN
+  integer   ::    nrec,mbul,dayofmonth,hourofday
+  integer,parameter :: lenhead=21,jrew=0
+  character * 1 :: a7,b7,c7,d7
+
+  CHARACTER * 6   BULHED
+  CHARACTER * 80  DESC,WMOHEAD
+  CHARACTER * 200  fileb,filei,fileo
+  CHARACTER * 6   envvar
+  CHARACTER * 4   KWBX
+  CHARACTER * 1   CSEP(80)
+  CHARACTER * 1   WMOHDR(lenhead)
+  character(len=1),pointer,dimension(:) :: gribm
+
+  logical :: extract=.false.
+
+  interface
+     SUBROUTINE GETGB2P(LUGB,LUGI,J,JDISC,JIDS,JPDTN,JPDT,JGDTN,JGDT, &
+          EXTRACT,K,GRIBM,LENG,IRET)
+       INTEGER,INTENT(IN) :: LUGB,LUGI,J,JDISC,JPDTN,JGDTN
+       INTEGER,DIMENSION(:) :: JIDS(*),JPDT(*),JGDT(*)
+       LOGICAL,INTENT(IN) :: EXTRACT
+       INTEGER,INTENT(OUT) :: K,IRET
+       CHARACTER(LEN=1),POINTER,DIMENSION(:) :: GRIBM
+     END SUBROUTINE GETGB2P
+  end interface
+  NAMELIST /GRIBIDS/DSCPL,IDS,GDTN,GDT,PDTN,PDT,DESC,WMOHEAD,EXTRACT
+
+  lugb=11      ! Input GRIB2 File
+  lugi=0      ! Input GRIB2 INdex File
+  lugo=51      ! Output transmission file.
+
+  !        Read GRIB2 data and index file names from the FORT_nn
+  !        environment variables, and open the files.
+  fileb='data/rrfs.t12z.prslevfaa.f010.na3km.grib2'
+  filei=''
+
+  call baopenr(lugb,fileb,iret1)
+  if (iret1  .ne. 0) then
+     write(6,fmt='(" Error opening GRIB file: ",A200)') fileb
+     write(6,fmt='(" baopenr error = ",I5)') iret1
+     stop 10
+  endif
+
+  !        Read output GRIB bulletin file name from  FORTnn
+  !        environment variable, and open file.
+  fileo='test_tocgrib2.output.grib2'
+  call baopenw(lugo,fileo,iret1)
+  if (iret1  .ne. 0) then
+     write(6,fmt='(" Error opening output transmission file: ", &
+          A200)') fileo
+     write(6,fmt='(" baopenw error = ",I5)') iret1
+     stop 20
+  endif
+
+  !        loop through input control records.
+  iret=0
+  nrec = 0
+  open(12, file='data/grib2.awips.rrfs.010')
+  foreachinputrecord: do
+
+     !  Set Namelist defaults
+     DSCPL=-1     ! Grib2 Discipline number
+     IDS=-9999    ! GRIB2 Identification Section
+     GDTN=-1      ! Grid Definition Template Number
+     GDT=-9999    ! Grid Definition Template
+     PDTN=-1      ! Product Definition Template Number
+     PDT=-9999    ! Product Definition Template
+     WMOHEAD='TTAAnn CCCC'
+     EXTRACT=.false.
+
+     READ (12,GRIBIDS,iostat=ios)
+     if (ios .ne. 0) then
+        write(6,fmt='(" Error reading PDS from input file. iostat = " &
+             ,i5)') ios
+        cycle
+     endif
+     nrec = nrec + 1
+
+     !  Echo input record
+     WRITE(6,FMT='(/,''***********************************'', &
+          ''********************************************'')')
+     write(6,'(A,I0)') ' Start new record no. =  ',nrec
+     write(6,'(73A)') ' DESC=',DESC(1:73)
+     write(6,'(11A)') ' WMOHEAD=',WMOHEAD(1:11)
+     write(6,'(A,I0)') ' GRIB2 DISCIPLINE= ',DSCPL
+     write(6,'(A,20(1x,I0))')' Section 1=', &
+          (IDS(j2),j2=1,13)
+     if (GDTN .ne. -1) then
+        write(6,'(A,I0,A,100(1x,I0))') ' GDT 3. ',GDTN,' =', &
+             (GDT(j2),j2=1,getgdtlen(GDTN))
+     endif
+     if (PDTN .ne. -1) then
+        write(6,'(A,I0,A,100(1x,I0))') ' PDT 4. ',PDTN,' =', &
+             (PDT(j2),j2=1,getpdtlen(PDTN))
+     endif
+
+     !        Read and return packed GRIB field
+     CALL GETGB2P(lugb,lugi,jrew,DSCPL,IDS,PDTN,PDT, &
+          GDTN,GDT,extract,KREW,gribm,itot,iret)
+     IF (IRET.NE.0) THEN
+        IF (IRET.EQ.96)WRITE(6,'(A)')' GETGB2P: ERROR READING INDEX' &
+             //' FILE'
+        IF (IRET.EQ.97)WRITE(6,'(A)')' GETGB2P: ERROR READING GRIB' &
+             //' FILE'
+        IF (IRET.EQ.99)WRITE(6,'(A)')' GETGB2P: ERROR REQUEST NOT' &
+             //' FOUND'
+        cycle
+     END IF
+     a7=gribm(size(gribm)-3)
+     b7=gribm(size(gribm)-2)
+     c7=gribm(size(gribm)-1)
+     d7=gribm(size(gribm))
+     if(.not.all((/a7,b7,c7,d7/).eq.'7')) stop 77
+  enddo foreachinputrecord
+
+END PROGRAM test_getgb2p_2

--- a/tests/test_getgb2p_2.F90
+++ b/tests/test_getgb2p_2.F90
@@ -118,6 +118,7 @@ PROGRAM test_getgb2p_2
      c7=gribm(size(gribm)-1)
      d7=gribm(size(gribm))
      if(.not.all((/a7,b7,c7,d7/).eq.'7')) stop 77
+     deallocate(gribm)
     return
   enddo foreachinputrecord
 


### PR DESCRIPTION
This PR adds a unit test for `getgb2p()` based on the newly added RRFS t12z awips file. This is the file that we have been having problems with processing with tocgrib2, including the [7777 issue](https://github.com/NOAA-EMC/NCEPLIBS-g2/issues/666).

Currently, on my personal machine, the test fails with a segfault. Not too surprisingly, the segfault goes away if I comment out the lines where the '7777' octets are added in `getgb2rp2()`, once again pointing to issues with the indexing for some messages.

Related to #666