### PR TITLE
turn on warnings for clang workflow build

### DIFF
--- a/.github/workflows/Linux_clang.yml
+++ b/.github/workflows/Linux_clang.yml
@@ -80,7 +80,7 @@ jobs:
         cd build
         clang --version
         gfortran --version
-        cmake ${{ matrix.config.options }} -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_C_FLAGE="-g -Wall" -DCMAKE_Fortran_FLAGS="-g -Wall" ..
+        cmake ${{ matrix.config.options }} -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_C_FLAGS="-g -Wall" -DCMAKE_Fortran_FLAGS="-g -Wall" ..
         make -j2 VERBOSE=1
 
     - name: cache-data

--- a/.github/workflows/Linux_clang.yml
+++ b/.github/workflows/Linux_clang.yml
@@ -80,7 +80,7 @@ jobs:
         cd build
         clang --version
         gfortran --version
-        cmake ${{ matrix.config.options }} -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data ..
+        cmake ${{ matrix.config.options }} -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_C_FLAGE="-g -Wall" -DCMAKE_Fortran_FLAGS="-g -Wall" ..
         make -j2 VERBOSE=1
 
     - name: cache-data


### PR DESCRIPTION
Turn on warnings for clang build. Fixes #745