### PR TITLE
Switch to fortran standard handling of arguments in utils

### DIFF
--- a/utils/cnvgrib.F90
+++ b/utils/cnvgrib.F90
@@ -34,7 +34,7 @@ program cnvgrib
   integer :: inver = 0, outver = 0, ipack = -1
   character(len = 500) :: gfilein, gfileout, copt
   character(len = 2) :: master_table_ver, curmastertab_ver
-  INTEGER(4) NARG, IARGC, table_ver, mastertab
+  INTEGER(4) NARG, table_ver, mastertab
   logical :: usemiss = .false., uvvect = .true.
   !
   !     Set current Master table version 2
@@ -44,7 +44,7 @@ program cnvgrib
   mastertab = 21    ! WMO GRIB2 version 21 (released in May 2, 2018)
 
   !  GET ARGUMENTS
-  NARG = IARGC()
+  NARG = command_argument_count()
   IF (NARG .lt. 3) THEN       ! may be a problem with args
      IF (NARG .eq. 0) THEN
         !CALL ERRMSG('cnvgrib:  Incorrect usage')
@@ -52,7 +52,7 @@ program cnvgrib
         CALL ERREXIT(2)
      ELSE                !  look for -h "help" option
         do j = 1, NARG
-           call getarg(j, copt)
+           call get_command_argument(j, copt)
            if (copt .eq. '-h' .or. copt .eq. '-help') then
               call usage(1)
               CALL ERREXIT(0)
@@ -64,7 +64,7 @@ program cnvgrib
   ELSE
      j = 1
      do while (j.le.NARG-2)        ! parse first narg-2 args
-        call getarg(j, copt)
+        call get_command_argument(j, copt)
         j = j+1
         selectcase(copt)
         case('-g12')
@@ -187,8 +187,8 @@ program cnvgrib
      !
      !   get filenames from last two arguments
      !
-     CALL GETARG(NARG-1, gfilein)
-     CALL GETARG(NARG, gfileout)
+     CALL get_command_argument(NARG-1, gfilein)
+     CALL get_command_argument(NARG, gfileout)
      !
      !   If -p option specified, must be writing out grib2
      !

--- a/utils/copygb.F90
+++ b/utils/copygb.F90
@@ -163,11 +163,11 @@ PROGRAM COPYGB
   DATA IDS/255*-9999/,IBS/255*-9999/,NBS/255*-9999/
 
   !  PARSE COMMAND LINE OPTIONS
-  NARG=IARGC()
+  NARG=command_argument_count()
   IARG=1
   LSTOPT=0
   DO WHILE(IARG.LE.NARG.AND.LSTOPT.EQ.0)
-     CALL GETARG(IARG,CARG)
+     CALL get_command_argument(IARG,CARG)
      LARG=LEN_TRIM(CARG)
      IARG=IARG+1
      IF(CARG(1:1).NE.'-') THEN
@@ -187,7 +187,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'A') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -208,7 +208,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'B') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -218,7 +218,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'b') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -228,7 +228,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'g') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -259,7 +259,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'i') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -272,7 +272,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'K') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -288,7 +288,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'k') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -307,7 +307,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'M') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -324,7 +324,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'m') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -334,7 +334,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'N') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -344,7 +344,7 @@ PROGRAM COPYGB
            ELSEIF(CARG(L:L).EQ.'v') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -381,7 +381,7 @@ PROGRAM COPYGB
      CALL EUSAGE
      CALL ERREXIT(NXARG)
   ENDIF
-  CALL GETARG(IARG,CG1)
+  CALL get_command_argument(IARG,CG1)
   LCG1=LEN_TRIM(CG1)
   IARG=IARG+1
   LG1=11
@@ -391,7 +391,7 @@ PROGRAM COPYGB
      CALL ERREXIT(8)
   ENDIF
   IF(LX.GT.0) THEN
-     CALL GETARG(IARG,CX1)
+     CALL get_command_argument(IARG,CX1)
      LCX1=LEN_TRIM(CX1)
      IARG=IARG+1
      LX1=31
@@ -403,7 +403,7 @@ PROGRAM COPYGB
   ELSE
      LX1=0
   ENDIF
-  CALL GETARG(IARG,CG2)
+  CALL get_command_argument(IARG,CG2)
   LCG2=LEN_TRIM(CG2)
   IARG=IARG+1
   IF(CG2(1:LCG2).EQ.'-') THEN

--- a/utils/copygb2.F90
+++ b/utils/copygb2.F90
@@ -174,11 +174,11 @@ PROGRAM COPYGB2
   DATA IDS/255*-9999/,IBS/255*-9999/,NBS/255*-9999/
 
   !  PARSE COMMAND LINE OPTIONS
-  NARG=IARGC()
+  NARG=command_argument_count()
   IARG=1
   LSTOPT=0
   DO WHILE(IARG.LE.NARG.AND.LSTOPT.EQ.0)
-     CALL GETARG(IARG,CARG)
+     CALL get_command_argument(IARG,CARG)
      LARG=LEN_TRIM(CARG)
      IARG=IARG+1
      IF(CARG(1:1).NE.'-') THEN
@@ -198,7 +198,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'A') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -222,7 +222,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'B') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -235,7 +235,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'b') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -248,7 +248,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'g') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -279,7 +279,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'i') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -292,7 +292,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'K') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -311,7 +311,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'k') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -330,7 +330,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'M') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -347,7 +347,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'m') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -357,7 +357,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'N') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -370,7 +370,7 @@ PROGRAM COPYGB2
            ELSEIF(CARG(L:L).EQ.'v') THEN
               IF(L.EQ.LARG) THEN
                  L=0
-                 CALL GETARG(IARG,CARG)
+                 CALL get_command_argument(IARG,CARG)
                  LARG=LEN_TRIM(CARG)
                  IARG=IARG+1
               ENDIF
@@ -401,7 +401,7 @@ PROGRAM COPYGB2
      CALL EUSAGE
      CALL ERREXIT(NXARG)
   ENDIF
-  CALL GETARG(IARG,CG1)
+  CALL get_command_argument(IARG,CG1)
   LCG1=LEN_TRIM(CG1)
   IARG=IARG+1
   LG1=11
@@ -411,7 +411,7 @@ PROGRAM COPYGB2
      CALL ERREXIT(8)
   ENDIF
   IF(LX.GT.0) THEN
-     CALL GETARG(IARG,CX1)
+     CALL get_command_argument(IARG,CX1)
      LCX1=LEN_TRIM(CX1)
      IARG=IARG+1
      LX1=31
@@ -423,7 +423,7 @@ PROGRAM COPYGB2
   ELSE
      LX1=0
   ENDIF
-  CALL GETARG(IARG,CG2)
+  CALL get_command_argument(IARG,CG2)
   LCG2=LEN_TRIM(CG2)
   IARG=IARG+1
   IF(CG2(1:LCG2).EQ.'-') THEN

--- a/utils/degrib2.F90
+++ b/utils/degrib2.F90
@@ -28,7 +28,7 @@ program degrib2
   character(len = 8) :: pabbrev
   character(len = 40) :: labbrev
   character(len = 110) :: tabbrev
-  integer(4) narg, iargc, temparg
+  integer(4) narg, temparg
   integer :: currlen = 0,  numpts = 0
   logical :: unpack, expand
   type(gribfield) :: gfld
@@ -39,7 +39,7 @@ program degrib2
   expand = .false.
 
   ! Get arguments.
-  narg = iargc()
+  narg = command_argument_count()
   if (narg .ne. 1) then
      call errmsg('degrib2:  incorrect usage')
      call errmsg('usage: degrib2 grib2file')
@@ -49,7 +49,7 @@ program degrib2
   ! Open the input file with the bacio library.
   ifl1 = 10
   temparg = 1
-  call getarg(temparg, gfile1)
+  call get_command_argument(temparg, gfile1)
   ncgb = len_trim(gfile1)
   call baopenr(ifl1, gfile1(1:ncgb), ios)
 

--- a/utils/grb2index.F90
+++ b/utils/grb2index.F90
@@ -14,7 +14,7 @@
 !> @author Iredell @date 1992-11-22
 program grb2index
   implicit none
-  integer narg, iargc
+  integer narg
   character cgb * 256, cgi * 256
   character cidxver * 1
   integer :: idxver = 2
@@ -32,7 +32,7 @@ program grb2index
   end interface
   
   ! Get arguments.
-  narg = iargc()
+  narg = command_argument_count()
   if (narg .ne. 2 .and. narg .ne. 3) then
      call errmsg('grb2index:  Incorrect usage')
      call errmsg('Usage: grb2index gribfile indexfile')
@@ -40,12 +40,12 @@ program grb2index
      call exit(2)
   endif
   if (narg .eq. 3) then
-     call getarg(1, cidxver)
+     call get_command_argument(1, cidxver)
      read(cidxver, '(i1)') idxver
      argnum = 1
   end if
-  call getarg(argnum + 1, cgb)
-  call getarg(argnum + 2, cgi)
+  call get_command_argument(argnum + 1, cgb)
+  call get_command_argument(argnum + 2, cgi)
 
   ! Open binary GRIB2 file for input.
   call baopenr(lugb, trim(cgb), ios)

--- a/utils/grbindex.f
+++ b/utils/grbindex.f
@@ -20,16 +20,16 @@
       PARAMETER(MBUF=256*1024)
       CHARACTER CBUF(MBUF)
       CHARACTER CARG*300
-      INTEGER NARG,IARGC
+      INTEGER NARG
 
 !  GET ARGUMENTS
-      NARG=IARGC()
+      NARG=command_argument_count()
       IF(NARG.NE.2) THEN
         CALL ERRMSG('grbindex:  Incorrect usage')
         CALL ERRMSG('Usage: grbindex gribfile indexfile')
         CALL ERREXIT(2)
       ENDIF
-      CALL GETARG(1,CGB)
+      CALL get_command_argument(1,CGB)
       NCGB=LEN_TRIM(CGB)
       CALL BAOPENR(11,CGB(1:NCGB),IOS)
       CALL BASETO(1,1)
@@ -39,7 +39,7 @@
         CALL ERRMSG(CARG(1:LCARG))
         CALL ERREXIT(8)
       ENDIF
-      CALL GETARG(2,CGI)
+      CALL get_command_argument(2,CGI)
       NCGI=LEN_TRIM(CGI)
       CALL BAOPEN(31,CGI(1:NCGI),IOS)
       IF(IOS.NE.0) THEN


### PR DESCRIPTION
Fixes NOAA-EMC/NCEPLIBS-grib_util#296

- [x] No generative AI tools were used to develop any of the code in this PR.