### PR TITLE
CI: add cron's and workflow_dispatch's

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -34,6 +34,7 @@ jobs:
     - name: "Install Intel"
       uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
+        oneapi-version: 2023.2.1
         compiler-setup: ${{ matrix.compilers }}
 
     - name: install-dependencies

--- a/.github/workflows/Linux_clang.yml
+++ b/.github/workflows/Linux_clang.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Linux_shared.yml
+++ b/.github/workflows/Linux_shared.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -25,7 +25,7 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
+      FC: gfortran-14
       CC: gcc
 
     strategy:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run biweekly
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/warnings.yml
+++ b/.github/workflows/warnings.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This PR updates CI workflows to run on cron's: biweekly for 'developer' workflow, monthly for the rest. It also adds workflow_dispatch triggers to enable running workflows manually.

Part of https://github.com/NOAA-EMC/NCEPLIBS/issues/237